### PR TITLE
Add Python helper to return today's date

### DIFF
--- a/today_date.py
+++ b/today_date.py
@@ -1,0 +1,6 @@
+from datetime import date
+
+
+def get_todays_date() -> date:
+    """Return today's local date."""
+    return date.today()


### PR DESCRIPTION
### Motivation
- Provide a tiny, reusable utility that returns the current local `datetime.date` for callers that need today's date as a `date` object.

### Description
- Add `today_date.py` with a single function `get_todays_date()` that returns `datetime.date.today()` and includes a short docstring and a return type annotation.

### Testing
- Ran `python -c "from today_date import get_todays_date; print(get_todays_date())"` which printed the current date and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61bed51f48330bf4ade46c7620042)