### PR TITLE
Add JST datetime formatter (Issue #4)

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+JST = timezone(timedelta(hours=9), name="JST")
+
+
+def format_jst(dt: datetime) -> str:
+    """Format a datetime in Japan Standard Time.
+
+    Naive datetimes are treated as UTC.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+
+    return dt.astimezone(JST).strftime("%Y-%m-%d %H:%M:%S JST")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,19 @@
+from datetime import UTC, datetime
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.core import format_jst
+
+
+def test_format_jst_converts_aware_datetime() -> None:
+    dt = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+    assert format_jst(dt) == "2024-01-01 09:00:00 JST"
+
+
+def test_format_jst_treats_naive_as_utc() -> None:
+    dt = datetime(2024, 1, 1, 0, 0, 0)
+
+    assert format_jst(dt) == "2024-01-01 09:00:00 JST"


### PR DESCRIPTION
### Motivation
- Provide a small utility to consistently format datetimes in Japan Standard Time for code that needs JST output.
- Ensure predictable behavior by treating naive `datetime` objects as UTC before conversion.
- No external skills or frameworks were required; the change is self-contained and minimal.

### Description
- Add `format_jst(dt: datetime) -> str` in `src/core.py` that converts a `datetime` to JST and returns `YYYY-MM-DD HH:MM:SS JST`.
- Treat naive `datetime` values as UTC by setting `tzinfo=UTC` before conversion.
- Add unit tests in `tests/test_core.py` covering both timezone-aware and naive datetimes (tests adjust `sys.path` for local import).
- A pull request was created from the branch `codex/issue-4-format-jst` targeting `main`; the PR tool did not return an externally-accessible URL from this environment.

### Testing
- Ran `pytest -q` and observed `2 passed` (test suite succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a621f0d3fc8330bececd1cc3f22870)