### PR TITLE
Add sqrt function to core module

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -14,3 +14,10 @@ def format_jst(dt: datetime) -> str:
         dt = dt.replace(tzinfo=UTC)
 
     return dt.astimezone(JST).strftime("%Y-%m-%d %H:%M:%S JST")
+
+
+def sqrt(x: float) -> float:
+    if x < 0:
+        raise ValueError("x must be non-negative")
+
+    return x ** 0.5

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,9 +2,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from src.core import format_jst
+from src.core import format_jst, sqrt
 
 
 def test_format_jst_converts_aware_datetime() -> None:
@@ -17,3 +19,16 @@ def test_format_jst_treats_naive_as_utc() -> None:
     dt = datetime(2024, 1, 1, 0, 0, 0)
 
     assert format_jst(dt) == "2024-01-01 09:00:00 JST"
+
+
+def test_sqrt_of_perfect_square() -> None:
+    assert sqrt(9) == 3
+
+
+def test_sqrt_of_two_is_approximate() -> None:
+    assert sqrt(2) == pytest.approx(1.4142, abs=1e-4)
+
+
+def test_sqrt_raises_for_negative_values() -> None:
+    with pytest.raises(ValueError):
+        sqrt(-1)


### PR DESCRIPTION
### Motivation
- Provide a simple square-root utility in the core module and validate inputs by raising on negative values to prevent invalid results.

### Description
- Add `sqrt(x: float) -> float` to `src/core.py` that returns `x ** 0.5` and raises `ValueError` when `x < 0`.
- Add tests in `tests/test_core.py` that import `sqrt` and `pytest` and verify `sqrt(9) == 3`, that `sqrt(2)` matches `pytest.approx(1.4142)` with an explicit tolerance, and that `sqrt(-1)` raises `ValueError`.
- Adjust the approximate assertion to use `pytest.approx(1.4142, abs=1e-4)` to allow a sensible absolute tolerance for the irrational result.

### Testing
- I ran `pytest` which initially failed due to a too-strict approximation tolerance (first run: `collected 5 items` with `1 failed, 4 passed` and a failure on the approx assertion).
- After loosening the tolerance, I re-ran `pytest` with the command `pytest` and the final result was `5 passed in 0.01s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69bef69d08330940992c71eb8beb4)