### PR TITLE
Add GitHub Actions CI workflow for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          else
+            pip install pytest
+          fi
+
+      - name: Run tests
+        run: PYTHONPATH=. pytest -q


### PR DESCRIPTION
### Motivation

- Add continuous integration to run the project's test suite on GitHub for PRs and pushes to `main` to satisfy Issue #10.

### Description

- Add a new workflow file at `.github/workflows/ci.yml` that defines a `CI` job which checks out the code and runs on `pull_request` and `push` to `main`.
- Configure the job to use Python `3.11` via `actions/setup-python@v5` and to install dependencies with `pip install -r requirements.txt` when `requirements.txt` exists, falling back to installing `pytest` otherwise.
- Run the test command as `PYTHONPATH=. pytest -q` so tests discover the local package layout, and keep changes minimal and scoped to CI only.

### Testing

- Ran the test suite locally with `PYTHONPATH=. pytest -q`, which completed successfully with `5 passed`.
- The workflow is set to run automatically on GitHub for `pull_request` and `push` events to `main` (no GitHub run was executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6aac9cab483308913978fe906317b)