### PR TITLE
Add `calc_risk_amount` utility and tests (Issue #12)

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -21,3 +21,10 @@ def sqrt(x: float) -> float:
         raise ValueError("x must be non-negative")
 
     return x ** 0.5
+
+
+def calc_risk_amount(balance: float, risk_pct: float) -> float:
+    if balance < 0 or risk_pct < 0:
+        raise ValueError("balance and risk_pct must be non-negative")
+
+    return balance * risk_pct / 100

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from src.core import format_jst, sqrt
+from src.core import calc_risk_amount, format_jst, sqrt
 
 
 def test_format_jst_converts_aware_datetime() -> None:
@@ -32,3 +32,22 @@ def test_sqrt_of_two_is_approximate() -> None:
 def test_sqrt_raises_for_negative_values() -> None:
     with pytest.raises(ValueError):
         sqrt(-1)
+
+
+def test_calc_risk_amount_for_one_percent() -> None:
+    assert calc_risk_amount(100000, 1) == 1000
+
+
+def test_calc_risk_amount_for_five_percent() -> None:
+    assert calc_risk_amount(20000, 5) == 1000
+
+
+@pytest.mark.parametrize(
+    ("balance", "risk_pct"),
+    [(-1, 1), (1000, -1), (-100, -1)],
+)
+def test_calc_risk_amount_raises_for_negative_inputs(
+    balance: float, risk_pct: float
+) -> None:
+    with pytest.raises(ValueError):
+        calc_risk_amount(balance, risk_pct)


### PR DESCRIPTION
### Motivation

- Provide a simple utility to compute the monetary risk amount from a `balance` and `risk_pct` for use in risk calculations. 
- Ensure inputs are validated to avoid silently returning incorrect results for invalid (negative) values.

### Description

- Implement `calc_risk_amount(balance: float, risk_pct: float) -> float` in `src/core.py` that returns `balance * risk_pct / 100` and raises `ValueError` if `balance < 0` or `risk_pct < 0`.
- Add tests in `tests/test_core.py` that assert `calc_risk_amount(100000, 1) == 1000` and `calc_risk_amount(20000, 5) == 1000`.
- Add parameterized tests to verify that negative `balance` or `risk_pct` values raise `ValueError`.
- No changes were made to CI workflows, `requirements.txt`, or unrelated files.

### Testing

- Ran the test suite with `pytest -q` and all tests passed.
- Test output: `10 passed in 0.02s` confirming the new tests and existing tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b007820c833095a263eca651b4c8)