### PR TITLE
Add calc_position_size for risk-based lot sizing

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -28,3 +28,24 @@ def calc_risk_amount(balance: float, risk_pct: float) -> float:
         raise ValueError("balance and risk_pct must be non-negative")
 
     return balance * risk_pct / 100
+
+
+def calc_position_size(
+    balance: float,
+    risk_pct: float,
+    stop_loss_pips: float,
+    pip_value_per_lot: float,
+) -> float:
+    if balance < 0:
+        raise ValueError("balance must be non-negative")
+    if risk_pct < 0:
+        raise ValueError("risk_pct must be non-negative")
+    if stop_loss_pips <= 0:
+        raise ValueError("stop_loss_pips must be greater than zero")
+    if pip_value_per_lot <= 0:
+        raise ValueError("pip_value_per_lot must be greater than zero")
+
+    risk_amount = balance * risk_pct / 100
+    risk_per_lot = stop_loss_pips * pip_value_per_lot
+
+    return risk_amount / risk_per_lot

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from src.core import calc_risk_amount, format_jst, sqrt
+from src.core import calc_position_size, calc_risk_amount, format_jst, sqrt
 
 
 def test_format_jst_converts_aware_datetime() -> None:
@@ -55,3 +55,29 @@ def test_calc_risk_amount_raises_for_negative_inputs(
 ) -> None:
     with pytest.raises(ValueError):
         calc_risk_amount(balance, risk_pct)
+
+
+def test_calc_position_size_for_one_percent_risk() -> None:
+    assert calc_position_size(100000, 1, 100, 100) == 0.1
+
+
+def test_calc_position_size_for_five_percent_risk() -> None:
+    assert calc_position_size(20000, 5, 50, 100) == 0.2
+
+
+@pytest.mark.parametrize(
+    ("balance", "risk_pct", "stop_loss_pips", "pip_value_per_lot"),
+    [
+        (-1, 1, 100, 100),
+        (100000, -1, 100, 100),
+        (100000, 1, 0, 100),
+        (100000, 1, -10, 100),
+        (100000, 1, 100, 0),
+        (100000, 1, 100, -1),
+    ],
+)
+def test_calc_position_size_raises_for_invalid_inputs(
+    balance: float, risk_pct: float, stop_loss_pips: float, pip_value_per_lot: float
+) -> None:
+    with pytest.raises(ValueError):
+        calc_position_size(balance, risk_pct, stop_loss_pips, pip_value_per_lot)


### PR DESCRIPTION
### Motivation
- Implement a function to compute position size (lots) from account balance, risk %, stop-loss in pips, and pip value per lot for risk-based money management.
- Ensure invalid inputs are rejected to avoid incorrect sizing (negative balance/risk, non-positive stop-loss or pip value).

### Description
- Added `calc_position_size(balance, risk_pct, stop_loss_pips, pip_value_per_lot)` to `src/core.py` which returns `position_size_lots = risk_amount / risk_per_lot`.
- The function computes `risk_amount = balance * risk_pct / 100` and `risk_per_lot = stop_loss_pips * pip_value_per_lot` and returns `risk_amount / risk_per_lot`.
- Input validation now raises `ValueError` for `balance < 0`, `risk_pct < 0`, `stop_loss_pips <= 0`, and `pip_value_per_lot <= 0`.
- Added unit tests in `tests/test_core.py` covering two normal cases (`0.1` and `0.2` lots) and parameterized invalid-input cases using `pytest.mark.parametrize` and `pytest.raises`.

### Testing
- Ran `pytest -q` locally and all tests passed: `19 passed in 0.04s`.
- The new tests specifically exercise the two example scenarios and the invalid input branches and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6caad7f4083308c87fa2ac9d60c13)